### PR TITLE
Bug Fix - Fixed crash on empty URL

### DIFF
--- a/src/KioskClient/Pages/Settings.xaml.cs
+++ b/src/KioskClient/Pages/Settings.xaml.cs
@@ -44,7 +44,7 @@ namespace KioskLibrary.Pages
             {
                 State = ApplicationStorage.GetFromStorage<SettingsViewModel>(Constants.SettingsViewModel);
 
-                if(State == null)
+                if (State == null)
                     State = new SettingsViewModel();
             }
             catch { }
@@ -93,13 +93,18 @@ namespace KioskLibrary.Pages
 
             (bool isValid, string message) = await HttpHelper.ValidateURI(State.UriPath, HttpStatusCode.Ok);
             State.PathValidationMessage = message;
-            tmpOrchestrationInstance = await Orchestrator.GetOrchestrationInstance(new Uri(State.UriPath));
+            State.IsUriPathVerified = isValid;
 
             if (isValid)
+            {
+                tmpOrchestrationInstance = await Orchestrator.GetOrchestrationInstance(new Uri(State.UriPath));
                 await ValidateOrchestration(tmpOrchestrationInstance, OrchestrationSource.URL);
+            }
             else
             {
-                Log($"Unable to resolve: {State.UriPath}");
+                State.Orchestration = null;
+                if (!string.IsNullOrEmpty(State.UriPath))
+                    Log($"Unable to resolve: {State.UriPath}");
                 Log("Orchestration failed validation!");
             }
         }


### PR DESCRIPTION
Fixed a crash when user attempted to load an empty Url. The log will now reflect the error and tell the user that the Url is empty