### PR TITLE
Feature/auto reconnect

### DIFF
--- a/src/KioskClient/Dialogs/Examples.xaml.cs
+++ b/src/KioskClient/Dialogs/Examples.xaml.cs
@@ -32,7 +32,7 @@ namespace KioskClient.Dialogs
 
         private Orchestration ComposeExampleOrchestration(string fileFormat)
         {
-            Orchestration orchestration = new Orchestration
+            Orchestration orchestration = new()
             {
                 Name = $"{Constants.Application.OrchestrationFileExample.Name}{fileFormat}",
                 PollingIntervalMinutes = 15,

--- a/src/KioskClient/KioskClient.csproj
+++ b/src/KioskClient/KioskClient.csproj
@@ -25,6 +25,10 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.16" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.16" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
@@ -129,6 +133,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Converters\BooleanToInvertedVisibilityConverter.cs" />
     <Compile Include="Converters\HideFileOrchestrationSourceConverter.cs" />
     <Compile Include="Converters\NullToVisibilityConverter.cs" />
@@ -144,9 +151,6 @@
     </Compile>
     <Compile Include="Pages\Actions\WebsitePage.xaml.cs">
       <DependentUpon>WebsitePage.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="Converters\InvertBooleanConverter.cs" />
     <Compile Include="MainPage.xaml.cs">
@@ -292,31 +296,31 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Humanizer.Core">
-      <Version>2.8.26</Version>
+      <Version>2.14.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter">
-      <Version>4.1.0</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
-      <Version>4.1.0</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.1.0</Version>
+      <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.5.0</Version>
+      <Version>2.8.4</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Exceptions">
-      <Version>6.0.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
-      <Version>4.1.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO">
       <Version>4.3.0</Version>

--- a/src/KioskClient/MainPage.xaml.cs
+++ b/src/KioskClient/MainPage.xaml.cs
@@ -22,6 +22,7 @@ using KioskLibrary.Orchestrations;
 using System.Threading.Tasks;
 using KioskLibrary.Actions;
 using KioskLibrary.Pages.Actions;
+using Microsoft.AppCenter.Utils.Synchronization;
 
 namespace KioskLibrary
 {

--- a/src/KioskClient/MainPage.xaml.cs
+++ b/src/KioskClient/MainPage.xaml.cs
@@ -7,15 +7,12 @@
  */
 
 using KioskLibrary.Pages;
-using KioskLibrary.Pages.Actions;
-using KioskLibrary.Actions;
 using System;
 using System.Collections.Generic;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using KioskClient.Dialogs;
 using KioskClient.Pages.PageArguments;
 using Serilog;
 using Serilog.Formatting.Json;
@@ -23,6 +20,8 @@ using Windows.Storage;
 using KioskLibrary.Common;
 using KioskLibrary.Orchestrations;
 using System.Threading.Tasks;
+using KioskLibrary.Actions;
+using KioskLibrary.Pages.Actions;
 
 namespace KioskLibrary
 {
@@ -85,7 +84,7 @@ namespace KioskLibrary
             _orchestrator.NextAction += NextAction;
             _orchestrator.OrchestrationCancelled += OrchestrationCancelled;
             _orchestrator.OrchestrationStatusUpdate += OrchestrationStatusUpdate;
-            _orchestrator.OrchestrationLoaded += _orchestrator_OrchestrationLoaded;
+            _orchestrator.OrchestrationLoaded += OrchestrationLoaded;
             OrchestrationStatusUpdate(Constants.Application.Main.AttemptingToLoadDefaultOrchestration);
 
             ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
@@ -100,8 +99,8 @@ namespace KioskLibrary
 
         protected async override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var startImmediatley = e.Parameter as bool?;
-            if (startImmediatley.HasValue && startImmediatley.Value)
+            var startImmediately = e.Parameter as bool?;
+            if (startImmediately.HasValue && startImmediately.Value)
                 await StartOrchestration();
             else
                 StartTimers();
@@ -148,7 +147,7 @@ namespace KioskLibrary
             TextBlock_Status.Text = status;
         }
 
-        private void _orchestrator_OrchestrationLoaded(Orchestration orchestration)
+        private void OrchestrationLoaded(Orchestration orchestration)
         {
             _orchestration = orchestration;
         }

--- a/src/KioskClient/Pages/Settings.xaml
+++ b/src/KioskClient/Pages/Settings.xaml
@@ -111,6 +111,14 @@
                             <TextBlock x:Name="TextBlock_FilePath" Grid.Row="1" Grid.Column="2" TextWrapping="Wrap" VerticalAlignment="Center" Text="{x:Bind Path=State.LocalPath, Mode=OneWay}" />
                         </Grid>
                     </Grid>
+                    <Button x:Name="Button_AutoReconnect" VerticalAlignment="Top" HorizontalAlignment="Right" Style="{ThemeResource ButtonRevealStyle}" Click="Button_AutoReconnect_Click" >
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <SymbolIcon Symbol="{x:Bind Path=State.AutoReconnectIcon, Mode=OneWay}"/>
+                                <TextBlock Text="{x:Bind Path=State.AutoReconnectText, Mode=OneWay}"/>
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
                 </StackPanel>
             </Grid>
 

--- a/src/KioskClient/Pages/Settings.xaml
+++ b/src/KioskClient/Pages/Settings.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   Copyright 2021
   City of Stanton
   Stanton, Kentucky
@@ -115,7 +115,7 @@
                         <Button.Content>
                             <StackPanel Orientation="Horizontal">
                                 <SymbolIcon Symbol="{x:Bind Path=State.AutoReconnectIcon, Mode=OneWay}"/>
-                                <TextBlock Text="{x:Bind Path=State.AutoReconnectText, Mode=OneWay}"/>
+                                <TextBlock Text="{x:Bind Path=State.AutoReconnectText, Mode=OneWay}" ToolTipService.ToolTip="When active, the orchestration will attempt to restart automatically when the timer expires."/>
                             </StackPanel>
                         </Button.Content>
                     </Button>

--- a/src/KioskClient/Pages/Settings.xaml.cs
+++ b/src/KioskClient/Pages/Settings.xaml.cs
@@ -40,7 +40,7 @@ namespace KioskLibrary.Pages
 
         private SettingsPageArguments _currentPageArguments;
         private readonly IHttpHelper _httpHelper;
-        private readonly IApplicationSettings _applicationStorage;
+        private readonly IApplicationStorage _applicationStorage;
         private Queue<TeachingTip> _walkThrough;
         private bool Walkthrough_StartingIsLocalState;
         private int Walkthrough_StartingPivotItem;
@@ -56,7 +56,7 @@ namespace KioskLibrary.Pages
             {
                 _httpHelper ??= new HttpHelper();
 
-                _applicationStorage ??= new ApplicationSettings();
+                _applicationStorage ??= new ApplicationStorage();
             }
             catch { }
 
@@ -79,7 +79,7 @@ namespace KioskLibrary.Pages
         /// </summary>
         /// <param name="httpHelper">The <see cref="IHttpHelper"/> to use for HTTP requests</param>
         /// <param name="applicationStorage">The <see cref="IApplicationSettings"/> to use for interacting with local application storage</param>
-        public Settings(IHttpHelper httpHelper, IApplicationSettings applicationStorage)
+        public Settings(IHttpHelper httpHelper, IApplicationStorage applicationStorage)
             : this()
         {
             _httpHelper = httpHelper;

--- a/src/KioskClient/Properties/AssemblyInfo.cs
+++ b/src/KioskClient/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 [assembly: ComVisible(false)]

--- a/src/KioskClient/ViewModels/SettingsViewModel.cs
+++ b/src/KioskClient/ViewModels/SettingsViewModel.cs
@@ -32,18 +32,19 @@ namespace KioskLibrary.ViewModels
         private Orchestration _orchestration;
         private bool _isUriLoading;
         private bool _isFileLoading;
-        private ObservableCollection<ValidationResult> _orchestrationValidation;
+        private bool _autoReconnect;
+        private int _autoReconnectTimeRemaining;
 
         /// <summary>
         /// Constructor
         /// </summary>
         public SettingsViewModel()
-            : base(new List<string>() { 
-                nameof(OrchestrationValidationResult), 
-                nameof(IsOrchestrationLoaded), 
-                nameof(IsOrchestrationValid), 
-                nameof(CanStart), 
-                nameof(CanLoadFile), 
+            : base(new List<string>() {
+                nameof(OrchestrationValidationResult),
+                nameof(IsOrchestrationLoaded),
+                nameof(IsOrchestrationValid),
+                nameof(CanStart),
+                nameof(CanLoadFile),
                 nameof(CanLoadUri),
                 nameof(OrchestrationSummaryActionCount),
                 nameof(OrchestrationSummaryIsValid),
@@ -59,9 +60,7 @@ namespace KioskLibrary.ViewModels
                 nameof(OrchestrationSummaryIsValid),
                 nameof(OrchestrationSummaryIsValidDisplay)
             })
-        {
-            _orchestrationValidation = new ObservableCollection<ValidationResult>();
-        }
+        { }
 
         /// <summary>
         /// The Uri Path
@@ -256,7 +255,7 @@ namespace KioskLibrary.ViewModels
         /// </summary>
         public string OrchestrationSummaryRuntime
         {
-            get { return new TimeSpan(0,0, Orchestration?.Actions?.Sum(x => x.Duration) ?? 0).Humanize(); }
+            get { return new TimeSpan(0, 0, Orchestration?.Actions?.Sum(x => x.Duration) ?? 0).Humanize(); }
         }
 
         /// <summary>
@@ -300,6 +299,56 @@ namespace KioskLibrary.ViewModels
             foreach (var p in properties)
                 if (p.CanRead && p.CanWrite)
                     p.SetValue(this, null, null);
+        }
+
+        /// <summary>
+        /// Is Auto-Reconnect enabled
+        /// </summary>
+        public bool AutoReconnect
+        {
+            get { return _autoReconnect; }
+            set
+            {
+                _autoReconnect = value;
+                NotifyPropertyChanged();
+
+                AutoReconnectIcon = ""; // This should trigger the re-evaluation
+
+            }
+        }
+
+        /// <summary>
+        /// The Auto-Reconnect icon
+        /// </summary>
+        public string AutoReconnectIcon
+        {
+            get { return _autoReconnect ? "Stop" : "Play"; }
+            set { NotifyPropertyChanged(); }
+        }
+
+        /// <summary>
+        /// Is Auto-Reconnect enabled
+        /// </summary>
+        public string AutoReconnectText
+        {
+            get { return $" Auto-Reconnect: {(AutoReconnect ? AutoReconnectTimeRemaining : "Disabled")}"; }
+            set { NotifyPropertyChanged(); }
+
+        }
+
+        /// <summary>
+        /// The Auto-Reconnect time remaining
+        /// </summary>
+        public int AutoReconnectTimeRemaining
+        {
+            get { return _autoReconnectTimeRemaining; }
+            set
+            {
+                _autoReconnectTimeRemaining = value;
+                NotifyPropertyChanged();
+
+                AutoReconnectText = "";
+            }
         }
     }
 }

--- a/src/KioskClient/ViewModels/SettingsViewModel.cs
+++ b/src/KioskClient/ViewModels/SettingsViewModel.cs
@@ -32,8 +32,8 @@ namespace KioskLibrary.ViewModels
         private Orchestration _orchestration;
         private bool _isUriLoading;
         private bool _isFileLoading;
-        private bool _autoReconnect;
-        private int _autoReconnectTimeRemaining;
+        private bool _autoReconnect = true;
+        private int _autoReconnectTimeRemaining = 60;
 
         /// <summary>
         /// Constructor

--- a/src/KioskLibrary/KioskLibrary.csproj
+++ b/src/KioskLibrary/KioskLibrary.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -146,16 +146,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Exceptions">
-      <Version>6.0.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>

--- a/src/KioskLibrary/Orchestrations/Orchestrator.cs
+++ b/src/KioskLibrary/Orchestrations/Orchestrator.cs
@@ -19,6 +19,7 @@ using KioskLibrary.Orchestrations;
 using Windows.ApplicationModel.Core;
 using KioskLibrary.Helpers;
 using Serilog;
+using System.Threading;
 
 namespace KioskLibrary.Orchestrations
 {
@@ -224,10 +225,7 @@ namespace KioskLibrary.Orchestrations
                     }
                 }
                 else
-                {
-                    OrchestrationStatusUpdate?.Invoke(Constants.Orchestrator.StatusMessages.OrchestrationInvalid);
-                    return;
-                }
+                    StopOrchestration(Constants.Orchestrator.StatusMessages.OrchestrationInvalid);
             }
             else
                 StopOrchestration(Constants.Orchestrator.StatusMessages.NoValidOrchestration);

--- a/src/OrchestrationPollingManager/OrchestrationPollingManager.csproj
+++ b/src/OrchestrationPollingManager/OrchestrationPollingManager.csproj
@@ -128,13 +128,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.10.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Exceptions">
-      <Version>6.0.0</Version>
+      <Version>8.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Common/CommonTestLibrary/CommonTestLibrary.csproj
+++ b/test/Common/CommonTestLibrary/CommonTestLibrary.csproj
@@ -127,13 +127,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.16.0</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>

--- a/test/Unit/KioskClient.Spec/KioskClient.Spec.csproj
+++ b/test/Unit/KioskClient.Spec/KioskClient.Spec.csproj
@@ -148,16 +148,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>16.8.3</Version>
+      <Version>17.6.3</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>

--- a/test/Unit/KioskClient.Spec/KioskClient.Spec.csproj
+++ b/test/Unit/KioskClient.Spec/KioskClient.Spec.csproj
@@ -156,9 +156,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>3.0.4</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.6.3</Version>
-    </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/test/Unit/KioskClient.Spec/Package.appxmanifest
+++ b/test/Unit/KioskClient.Spec/Package.appxmanifest
@@ -7,7 +7,7 @@
 
   <Identity Name="dfffadb6-91dd-47b9-b2a8-a90382b93b13"
             Publisher="CN=chadb"
-            Version="1.0.0.0" />
+            Version="1.1.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="dfffadb6-91dd-47b9-b2a8-a90382b93b13" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/test/Unit/KioskLibrary.Spec/KioskLibrary.Spec.csproj
+++ b/test/Unit/KioskLibrary.Spec/KioskLibrary.Spec.csproj
@@ -152,19 +152,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.16.0</Version>
+      <Version>4.18.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>16.8.3</Version>
+      <Version>17.6.3</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>

--- a/test/Unit/KioskLibrary.Spec/KioskLibrary.Spec.csproj
+++ b/test/Unit/KioskLibrary.Spec/KioskLibrary.Spec.csproj
@@ -163,9 +163,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>3.0.4</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.6.3</Version>
-    </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/test/Unit/KioskLibrary.Spec/Orchestrations/OrchestratorSpec.cs
+++ b/test/Unit/KioskLibrary.Spec/Orchestrations/OrchestratorSpec.cs
@@ -21,7 +21,7 @@ namespace KioskLibrary.Spec.Orchestrations
             var currentOrchestrationPath = $"http://{CreateRandomString()}";
             var testOrchestration = CreateRandomOrchestration();
             var testOrchestrationAsString = SerializationHelper.JSONSerialize(testOrchestration);
-            var mockApplicationStorage = new Mock<IApplicationSettings>();
+            var mockApplicationStorage = new Mock<IApplicationStorage>();
             var mockhttphelper = new Mock<IHttpHelper>();
 
             var responseMessage = new HttpResponseMessage(HttpStatusCode.Ok)
@@ -52,7 +52,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [TestMethod]
         public async Task GetNextOrchestrationFailsTest()
         {
-            var mockApplicationStorage = new Mock<IApplicationSettings>();
+            var mockApplicationStorage = new Mock<IApplicationStorage>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 
@@ -68,7 +68,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [TestMethod]
         public async Task StartOrchestrationWithNoValidOrchestrationStoredTest()
         {
-            var mockApplicationStorage = new Mock<IApplicationSettings>();
+            var mockApplicationStorage = new Mock<IApplicationStorage>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 
@@ -87,7 +87,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [DataRow(OrchestrationSource.URL)]
         public async Task StartOrchestrationTest(OrchestrationSource orchestrationSource)
         {
-            var mockApplicationStorage = new Mock<IApplicationSettings>();
+            var mockApplicationStorage = new Mock<IApplicationStorage>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 

--- a/test/Unit/KioskLibrary.Spec/Orchestrations/OrchestratorSpec.cs
+++ b/test/Unit/KioskLibrary.Spec/Orchestrations/OrchestratorSpec.cs
@@ -21,7 +21,7 @@ namespace KioskLibrary.Spec.Orchestrations
             var currentOrchestrationPath = $"http://{CreateRandomString()}";
             var testOrchestration = CreateRandomOrchestration();
             var testOrchestrationAsString = SerializationHelper.JSONSerialize(testOrchestration);
-            var mockApplicationStorage = new Mock<IApplicationStorage>();
+            var mockApplicationStorage = new Mock<IApplicationSettings>();
             var mockhttphelper = new Mock<IHttpHelper>();
 
             var responseMessage = new HttpResponseMessage(HttpStatusCode.Ok)
@@ -52,7 +52,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [TestMethod]
         public async Task GetNextOrchestrationFailsTest()
         {
-            var mockApplicationStorage = new Mock<IApplicationStorage>();
+            var mockApplicationStorage = new Mock<IApplicationSettings>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 
@@ -68,7 +68,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [TestMethod]
         public async Task StartOrchestrationWithNoValidOrchestrationStoredTest()
         {
-            var mockApplicationStorage = new Mock<IApplicationStorage>();
+            var mockApplicationStorage = new Mock<IApplicationSettings>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 
@@ -87,7 +87,7 @@ namespace KioskLibrary.Spec.Orchestrations
         [DataRow(OrchestrationSource.URL)]
         public async Task StartOrchestrationTest(OrchestrationSource orchestrationSource)
         {
-            var mockApplicationStorage = new Mock<IApplicationStorage>();
+            var mockApplicationStorage = new Mock<IApplicationSettings>();
             var mockhttphelper = new Mock<IHttpHelper>();
             var mockTimeHelper = new Mock<ITimeHelper>();
 

--- a/test/Unit/OrchestrationPollingManager.Spec/OrchestrationPollingManager.Spec.csproj
+++ b/test/Unit/OrchestrationPollingManager.Spec/OrchestrationPollingManager.Spec.csproj
@@ -148,16 +148,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.11</Version>
+      <Version>6.2.14</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>3.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>16.8.3</Version>
+      <Version>17.6.3</Version>
     </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>

--- a/test/Unit/OrchestrationPollingManager.Spec/OrchestrationPollingManager.Spec.csproj
+++ b/test/Unit/OrchestrationPollingManager.Spec/OrchestrationPollingManager.Spec.csproj
@@ -156,9 +156,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>3.0.4</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.6.3</Version>
-    </PackageReference>
     <PackageReference Include="System.Xml.XDocument">
       <Version>4.3.0</Version>
     </PackageReference>


### PR DESCRIPTION
# Summary

This PR should address #38. The auto-reconnect will attempt to run the orchestration every 60 seconds until stopped. Once stopped, it can be resumed, but will revert to the default behavior of connecting in 60 seconds once the orchestration runs.

# Screenshots

## Countdown timer active
![image](https://github.com/CityOfStanton/Kiosk-Client/assets/24669724/d4179c37-f4e8-4928-b6f0-762914500a81)

## Countdown timer paused
![image](https://github.com/CityOfStanton/Kiosk-Client/assets/24669724/00df1cd1-59ad-47ab-b323-0eb5bf49068c)

# Additional work in this PR
 
I also updated all libraries to their latest versions. In particular, [Newtwonsoft.Json had a known issue](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). This needed to be addressed.